### PR TITLE
Github 관련 속성에서 spring.social 제거

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         java-version: 13
     - name: Build with Gradle
-      run: ./gradlew build -Dspring.social.github.token=${{ secrets.githubAccessToken }}
+      run: ./gradlew build -Dgithub.token=${{ secrets.githubAccessToken }}

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ Classifer를 통해 message출력되는 DB의 Comment 메세지 값들을 table�
 
 ## 기술적인 추가사항
 
--Dspring.social.github.token='' 으로 옵션 추가하면 github token로 갈아끼울수 있습니다. (파일에 있는것보다 -D 옵션이 우선순위가 높습니다.)
+-Dgithub.token='' 으로 옵션 추가하면 github token로 갈아끼울수 있습니다. (파일에 있는것보다 -D 옵션이 우선순위가 높습니다.)
 -Dspring.h2.console.settings.web-allow-others=true

--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,9 @@ dependencies {
 
 test {
 	useJUnitPlatform()
-	def token = System.getProperty("spring.social.github.token")
+	def token = System.getProperty("github.token")
 	println("Github Access Token : ${token}")
-	systemProperty "spring.social.github.token", token
+	systemProperty "github.token", token
 }
 
 editorconfig {

--- a/src/main/java/com/naver/hackday/devcenterbot/Message.java
+++ b/src/main/java/com/naver/hackday/devcenterbot/Message.java
@@ -20,7 +20,7 @@ public class Message {
 	private MessageModel model;
 
 	public Message(
-		@Value("${spring.social.github.token}") String token) {
+		@Value("${github.token}") String token) {
 
 		logger.info("token={}", token);
 		var client = new GitHubClient();

--- a/src/main/java/com/naver/hackday/devcenterbot/bot/BotClassifier.java
+++ b/src/main/java/com/naver/hackday/devcenterbot/bot/BotClassifier.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.naver.hackday.devcenterbot.Message;
-import com.naver.hackday.devcenterbot.entity.Brain;
 import com.naver.hackday.devcenterbot.model.BotRequest;
 import com.naver.hackday.devcenterbot.model.MessageModel;
 import com.naver.hackday.devcenterbot.persistence.BrainDao;
@@ -18,10 +17,10 @@ public class BotClassifier {
 	private MessageModel model;
 	private Message message;
 
-	@Value("${spring.social.github.user}")
+	@Value("${github.user}")
 	private String user;
 
-	@Value("${spring.social.github.repo}")
+	@Value("${github.repo}")
 	private String repo;
 
 	@Autowired

--- a/src/main/java/com/naver/hackday/devcenterbot/model/TitleScrapper.java
+++ b/src/main/java/com/naver/hackday/devcenterbot/model/TitleScrapper.java
@@ -17,10 +17,10 @@ public class TitleScrapper {
 	private IssueQueue queue;
 	private IssueService issueService;
 
-	@Value("${spring.social.github.user}")
+	@Value("${github.user}")
 	private String user;
 
-	@Value("${spring.social.github.repo}")
+	@Value("${github.repo}")
 	private String repo;
 
 	public TitleScrapper() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,11 +4,10 @@ spring:
     url: jdbc:h2:~/hackday/devcenter-bot;AUTO_SERVER=TRUE;MODE=MySQL
     continue-on-error: true
 
-  social:
-    github:
-      user: kkyehit
-      repo: egit-github-test
-      #token: OS환경변수나 -Dsocial.github.token 값 등으로 설정
+github:
+  user: kkyehit
+  repo: egit-github-test
+  #token: OS환경변수나 -Dsocial.github.token 값 등으로 설정
 
 logging:
   level:


### PR DESCRIPTION
아래 2가지 이유로 `spring.social.github` 속성 접미사를 `github`로 대체합니다.

- CLI등에서 입력하기에 더 간편하게 합니다. 'spring.social.github.token' 대신 'github.token' 을 써도 충분히 이 속성의 용도에 대해서 의미가 전달된다고 판단했습니다.
- 이 파일만 처음본 사람은  `spring.social.github` 이라는 속성명을 보면 [Spring Social Github](https://github.com/spring-projects/spring-social-github) 모듈을 의존하고 있다는 오해를 할 가능성 같습니다. README.md 에 egit-github를 쓰고 있다고는 되어 있지만, `spring.social.github`라는 속성명을 본다면 build.gradle으로 실제 의존성을  한번 더 확인해보게 될것 같습니다.
